### PR TITLE
Halve XP gained from selling tonewood

### DIFF
--- a/src/main/java/net/openbagtwo/foxnap/villagers/MusicAndArts.java
+++ b/src/main/java/net/openbagtwo/foxnap/villagers/MusicAndArts.java
@@ -125,7 +125,7 @@ public class MusicAndArts implements TradeOffers.Factory {
    * Factory to enable a villager to buy tonewood at a base rate of 4 blocks / 1 emerald
    */
   public static final TradeOffers.Factory BUY_TONEWOOD = new BuyItemFromPoolForOneEmeraldFactory(
-      TONEWOODS, 4, 16, 8);
+      TONEWOODS, 4, 16, 4);
 
   /**
    * Factory to enable a villager to buy noteblocks at a base rate of 2 blocks / 1 emerald

--- a/src/main/java/net/openbagtwo/foxnap/villagers/MusicAndArts.java
+++ b/src/main/java/net/openbagtwo/foxnap/villagers/MusicAndArts.java
@@ -125,7 +125,7 @@ public class MusicAndArts implements TradeOffers.Factory {
    * Factory to enable a villager to buy tonewood at a base rate of 4 blocks / 1 emerald
    */
   public static final TradeOffers.Factory BUY_TONEWOOD = new BuyItemFromPoolForOneEmeraldFactory(
-      TONEWOODS, 4, 16, 4);
+      TONEWOODS, 4, 16, 2);
 
   /**
    * Factory to enable a villager to buy noteblocks at a base rate of 2 blocks / 1 emerald

--- a/src/main/java/net/openbagtwo/foxnap/villagers/MusicAndArts.java
+++ b/src/main/java/net/openbagtwo/foxnap/villagers/MusicAndArts.java
@@ -125,7 +125,7 @@ public class MusicAndArts implements TradeOffers.Factory {
    * Factory to enable a villager to buy tonewood at a base rate of 4 blocks / 1 emerald
    */
   public static final TradeOffers.Factory BUY_TONEWOOD = new BuyItemFromPoolForOneEmeraldFactory(
-      TONEWOODS, 4, 16, 2);
+      TONEWOODS, 4, 16, 3);
 
   /**
    * Factory to enable a villager to buy noteblocks at a base rate of 2 blocks / 1 emerald


### PR DESCRIPTION
Resolves #4 

This is twice as much XP as a mason villager gets from buying clay balls, which I feel like is fair given how much of a pain in the toucans it is to get **stripped** wood--not logs, wood.