### PR TITLE
Set default track duration to 60 seconds instead of 5 minutes.

### DIFF
--- a/src/main/java/net/openbagtwo/foxnap/discs/DiscRegistry.java
+++ b/src/main/java/net/openbagtwo/foxnap/discs/DiscRegistry.java
@@ -56,7 +56,7 @@ public class DiscRegistry {
           registerDisc(
               String.format("track_%d", i),
               (i - 1) % 15 + 1,
-              5 * 60
+              60
           )
       );
     }


### PR DESCRIPTION
Resolves #31

Confirmed working as intended in Minecraft 1.19.2 when used with the SBM-Jukebox mod v1.0.7 ("Thus Sprach Zarathustra" was pulled out by the hopper before the track finished)