### PR TITLE
Create placeholder registry entries for large numbers of tracks

### DIFF
--- a/src/main/java/net/openbagtwo/foxnap/FoxNap.java
+++ b/src/main/java/net/openbagtwo/foxnap/FoxNap.java
@@ -24,7 +24,10 @@ public class FoxNap implements ModInitializer {
     Map<String, Object> settings = Config.readModSettings();
     LOGGER.info("Registering " + MOD_NAME);
     List<SecretlyJustAGoatHorn> instruments = InstrumentRegistry.init();
-    List<MusicDiscItem> custom_discs = DiscRegistry.init((int) settings.get("n_discs"));
+    List<MusicDiscItem> custom_discs = DiscRegistry.init(
+        (int) settings.get("n_discs"),
+        (int) settings.get("max_discs")
+    );
     Conductor.init(instruments, custom_discs);
     LOGGER.info(MOD_NAME + " Initialization Complete");
   }

--- a/src/main/java/net/openbagtwo/foxnap/config/Config.java
+++ b/src/main/java/net/openbagtwo/foxnap/config/Config.java
@@ -21,11 +21,24 @@ import org.yaml.snakeyaml.Yaml;
  */
 public class Config {
 
+  /**
+   * Path to the config file
+   */
   private static final Path config_path = FabricLoader.getInstance().getConfigDir()
       .resolve(MOD_ID + ".yaml").toAbsolutePath();
 
+  /**
+   * (Most) default settings
+   */
   public static final ImmutableMap<String, Object> DEFAULTS = ImmutableMap.of(
       "n_discs", 7
+  );
+
+  /**
+   * "Secret" default settings that shouldn't be written to the auto-generated config file
+   */
+  public static final ImmutableMap<String, Object> HIDDEN_DEFAULTS = ImmutableMap.of(
+      "max_discs", 64
   );
 
   private static final DumperOptions configFormat = new DumperOptions() {{
@@ -59,7 +72,9 @@ public class Config {
    * @return map of str key to the configuration value
    */
   public static Map<String, Object> readModSettings() {
-    HashMap<String, Object> settings = new HashMap<>(DEFAULTS);
+    HashMap<String, Object> settings = new HashMap<>(HIDDEN_DEFAULTS);
+    settings.putAll(DEFAULTS);
+
     LOGGER.info("Reading " + MOD_NAME + " configuration from " + config_path);
     FileInputStream configReader;
     try {

--- a/src/main/java/net/openbagtwo/foxnap/discs/Disc.java
+++ b/src/main/java/net/openbagtwo/foxnap/discs/Disc.java
@@ -14,17 +14,22 @@ public class Disc extends MusicDiscItem {
   /**
    * Create a new music disc
    *
-   * @param comparatorOutput the output signal a comparator should read from a jukebox with this
-   *                         disc loaded
-   * @param sound            the sound (track) a jukebox with this disc loaded should play
-   * @param trackLength      The length of the track in seconds. This value is currently only used
-   *                         by Allays (presumably to determine when to stop dancing and duping?).
+   * @param comparatorOutput  the output signal a comparator should read from a jukebox with this
+   *                          disc loaded
+   * @param sound             the sound (track) a jukebox with this disc loaded should play
+   * @param trackLength       The length of the track in seconds. This value is currently only used
+   *                          by Allays (presumably to determine when to stop dancing and duping?).
+   * @param creativeInventory whether the disc should appear in the creative inventory
    */
-  public Disc(int comparatorOutput, SoundEvent sound, int trackLength) {
-    super(comparatorOutput, sound, generateSettings(), trackLength);
+  public Disc(int comparatorOutput, SoundEvent sound, int trackLength, boolean creativeInventory) {
+    super(comparatorOutput, sound, generateSettings(creativeInventory), trackLength);
   }
 
-  private static Item.Settings generateSettings() {
-    return new Item.Settings().rarity(Rarity.RARE).maxCount(1).group(ItemGroup.MISC);
+  private static Item.Settings generateSettings(boolean creativeInventory) {
+    Item.Settings settings = new Item.Settings().rarity(Rarity.RARE).maxCount(1);
+    if (creativeInventory) {
+      settings = settings.group(ItemGroup.MISC);
+    }
+    return settings;
   }
 }

--- a/src/main/java/net/openbagtwo/foxnap/discs/DiscRegistry.java
+++ b/src/main/java/net/openbagtwo/foxnap/discs/DiscRegistry.java
@@ -29,15 +29,23 @@ public class DiscRegistry {
         new Identifier(FoxNap.MOD_ID, trackName),
         new Disc(comparatorOutput, registerTrack(trackName), trackLength)
     );
-    FoxNap.LOGGER.info(
+    FoxNap.LOGGER.debug(
         "Registered " + trackName
             + " with comparator signal " + disc.getComparatorOutput()
     );
     return disc;
   }
 
-  private static SoundEvent registerTrack(String track_name) {
-    Identifier track_id = new Identifier(FoxNap.MOD_ID, track_name);
+  public static void registerPlaceholderDisc(String trackName) {
+    Registry.register(
+        Registry.ITEM,
+        new Identifier(FoxNap.MOD_ID, trackName),
+        new Disc(0, registerTrack(trackName), 0)
+    );
+  }
+
+  private static SoundEvent registerTrack(String trackName) {
+    Identifier track_id = new Identifier(FoxNap.MOD_ID, trackName);
     return Registry.register(Registry.SOUND_EVENT, track_id, new SoundEvent(track_id));
   }
 
@@ -46,12 +54,12 @@ public class DiscRegistry {
    * with a sound event name track_i and emitting a comparator signal of strength i), starting at i
    * = 1
    *
-   * @param number_of_discs The number of discs to generate and register
+   * @param numberOfDiscs The number of discs to generate and register
    * @return A list of fully instantiated and registered music discs
    */
-  public static List<MusicDiscItem> init(int number_of_discs) {
+  public static List<MusicDiscItem> init(int numberOfDiscs) {
     ArrayList<MusicDiscItem> discs = new ArrayList<>();
-    for (int i = 1; i <= number_of_discs; i++) {
+    for (int i = 1; i <= numberOfDiscs; i++) {
       discs.add(
           registerDisc(
               String.format("track_%d", i),
@@ -61,5 +69,24 @@ public class DiscRegistry {
       );
     }
     return discs;
+  }
+
+  /**
+   * In addition to the procedurally-generated set of usable music discs, also generate extra
+   * dummy/placeholder discs to prevent client/server conflicts
+   *
+   * @param numberOfDiscs    The number of discs that will actually be available for use
+   * @param maxNumberOfDiscs The total number of discs to register
+   * @return The list of discs that should actually be available for use
+   */
+  public static List<MusicDiscItem> init(int numberOfDiscs, int maxNumberOfDiscs) {
+    int placeholderCount = 0;
+    for (int i = numberOfDiscs + 1; i <= maxNumberOfDiscs; i++) {
+      registerPlaceholderDisc(String.format("track_%d", i));
+      placeholderCount++;
+    }
+    FoxNap.LOGGER.debug(String.format("Registered %d placeholder discs", placeholderCount));
+
+    return init(numberOfDiscs);
   }
 }

--- a/src/main/java/net/openbagtwo/foxnap/discs/DiscRegistry.java
+++ b/src/main/java/net/openbagtwo/foxnap/discs/DiscRegistry.java
@@ -27,7 +27,7 @@ public class DiscRegistry {
     Disc disc = Registry.register(
         Registry.ITEM,
         new Identifier(FoxNap.MOD_ID, trackName),
-        new Disc(comparatorOutput, registerTrack(trackName), trackLength)
+        new Disc(comparatorOutput, registerTrack(trackName), trackLength, true)
     );
     FoxNap.LOGGER.debug(
         "Registered " + trackName
@@ -40,7 +40,7 @@ public class DiscRegistry {
     Registry.register(
         Registry.ITEM,
         new Identifier(FoxNap.MOD_ID, trackName),
-        new Disc(0, registerTrack(trackName), 0)
+        new Disc(0, registerTrack(trackName), 0, false)
     );
   }
 

--- a/src/main/java/net/openbagtwo/foxnap/instruments/InstrumentRegistry.java
+++ b/src/main/java/net/openbagtwo/foxnap/instruments/InstrumentRegistry.java
@@ -60,7 +60,7 @@ public class InstrumentRegistry {
     ArrayList<SecretlyJustAGoatHorn> instruments = new ArrayList<>();
     for (String instrument : INSTRUMENTS.keySet()) {
       instruments.add(registerInstrument(instrument));
-      FoxNap.LOGGER.info("Registered " + instrument);
+      FoxNap.LOGGER.debug("Registered " + instrument);
     }
     return instruments;
 

--- a/src/main/java/net/openbagtwo/foxnap/villagers/MusicAndArts.java
+++ b/src/main/java/net/openbagtwo/foxnap/villagers/MusicAndArts.java
@@ -176,18 +176,29 @@ public class MusicAndArts implements TradeOffers.Factory {
   }
 
   /**
-   * Create a trade factory for buying mod-custom music discs from the villager, which is intended
-   * as the only way for these discs to be obtainable outside of commands and the creative
-   * inventory. The intention is for these to be exclusively max-level trades.
+   * Create a trade factory for buying mod-custom music discs from the villager. These are intended
+   * to be max-level trades exclusively. Use this method (supplying a list of discs) if you want the
+   * villager's two max-level trade slots to pull from separate disc pools or if you want each
+   * Conductor to only sell one disc (you sadist)
    *
    * @param discs The discs a villager might sell
-   * @return Trade factory that will enable the villager to sell an instrument at a base rate of 32
-   * emeralds per instrument
+   * @return Trade factory that will enable the villager to sell a music disc at a base rate of 32
+   * emeralds per disc
    */
   public static TradeOffers.Factory sellMusicDisc(List<MusicDiscItem> discs) {
     return new SellOneItemFromPoolFactory(discs, 32, 3, 30);
   }
 
+  /**
+   * Create a trade factory for buying mod-custom music discs from the villager. These are intended
+   * to be max-level trades exclusively. Creating a TradeOffers.Factory by using this method
+   * (providing a single disc at a time) and looping over all available discs ensures that the
+   * Conductor will offer two randomly selected records (without replacement).
+   *
+   * @param disc A disc a villager might sell
+   * @return Trade factory that will enable the villager to sell a music disc at a base rate of 32
+   * emeralds per disc
+   */
   public static TradeOffers.Factory sellMusicDisc(MusicDiscItem disc) {
     return new SellItemFactory(disc, 32, 1, 3, 30);
   }


### PR DESCRIPTION
Band-aid solution to resolve #34 

It was a fundamental misunderstanding on my part to think that only [the logical server](https://fabricmc.net/wiki/tutorial:side) kept track of the item registry or that the item registry could be modified after launch (this has broader implications for any planned ModMenu integration). Even looking at several mods which have configs that customize the items registered _and_ have settings adjustable via ModMenu, the item options are **never** tweakable without a restart.

So given that the number of tracks needs to a value that is:
- fixed on Minecraft launch
- consistent[1] between server and client

I went ahead and [semi-hard-coded it](https://github.com/OpenBagTwo/FoxNap/blob/daf9d88cc42526bb5fbdaa76533a41b37b677cf6/src/main/java/net/openbagtwo/foxnap/config/Config.java#L37-L42) to an absurdly high number.



This appears to work as intended on 1.19.2, because large parts of the Minecraft logic _are_ implicitly logical-server-side or client-side. Namely, I have verified, with varying `n_disc` values set on independently on server and client, that:
- the creative inventory is handled exclusively on the client-side (and thus 22d79ce67f7436796291b6081048de6d7b262b62 works as intended) [2]
- comparator outputs are handled exclusively by the logical server (as I've set placeholder discs to universally have a comparator output strength of 0)
- villager trades are handled exclusively by the logical server [3]


### Outstanding Issues
- Note that `max_discs` is technically the _minimum_ number of discs--if `n_discs` is greater than `max_discs`, then all `n_discs` will be fully registered. This means that the whole "infinite tracks" stuff is still 100% valid, but if you're playing on a server with `n_discs` > 64, you're going to need to update `max_discs` on the client as well ([while the error message for this is pretty clear](https://github.com/OpenBagTwo/FoxNap/issues/8#issuecomment-1343830518) to me, the mod's developer, this is absolutely something that should be caught and handled gracefully ([BCLib](https://github.com/quiqueck/BCLib) has this great thing that offers to fix the the config issue and then prompts you to restart the game)
- if the server's `n_discs` is greater than 7 and the client does not have any resource packs giving the textures for records beyond 7, they'll have no play sound (fine), no language entry (meh) and no texture (ew). This issue was already captured as #29.
- Players in single-player or multiplayer with access to commands can obtain placeholder tracks (meh)
- Once these changes are applied to the other branches, they will require **explicitly testing** with 1.19 and 1.19.3 (meaning we gotta reopen #8)
- Unless the player is using a resource pack with **64 tracks specified** their logs--on single-player or multiplayer--are going to get flooded with warnings about missing textures and sound files. This will also be resolved via #29.

Of these, only that last item (plus the validation story) I would consider as having any sort of severity, so I may watch some tutorials to see if I can get that figured out for the initial release.

### Footnotes

[1] as [I mentioned](https://github.com/OpenBagTwo/FoxNap/issues/8#issuecomment-1343830518) when I originally ran up against this issue, it does seem like the experience is functional if the server has _fewer_ records registered than the client, but the behavior seemed extremely glitchy

<details><summary>[2] with client-side n_discs set to 3 and server-side n_discs set to 5, only records 1-3 show up in the creative inventory</summary>

![with client-side n_discs set to 3 and server-side n_discs set to 5, only records 1-3 show up in the creative inventory](https://user-images.githubusercontent.com/66568922/206779456-5596842b-68df-4d79-a43e-f9912d076dae.png)
</details>

<details><summary>[3] with client-side n_discs set to 3 and server-side n_discs set to 5, villagers will still offer discs 4 and 5</summary>

![with client-side n_discs set to 3 and server-side n_discs set to 5, villagers will still offer discs 4 and 5](https://user-images.githubusercontent.com/66568922/206779728-99aaf528-861e-443c-88c2-641da71d2a0f.png)
</details>

