### PR TITLE
Fix config normalizing

### DIFF
--- a/foxnap_rpg/config.py
+++ b/foxnap_rpg/config.py
@@ -84,19 +84,19 @@ def _parse_csv(config_path: Path) -> list[dict[str, Any]]:
 def _convert_dict_to_spec(as_dict: dict[str, Any]) -> Spec:
     spec_fields = {field_name: None for field_name in Spec._fields}
 
-    as_dict = {k: v for k, v in as_dict.items() if _check_none(v) is not None}
+    # TODO: error if k.lower() results in duplicate keys
+    as_dict = {k.lower(): v for k, v in as_dict.items() if _check_none(v) is not None}
 
     def normalize(spec_field: str, *possible_key_names: str):
         for key_name in (spec_field, *possible_key_names):
             for key in {
                 key_name,
-                key_name.upper(),
                 key_name.replace("_", "-"),
                 key_name.replace("_", " "),
                 key_name.replace("_", ""),
             }:
                 if key in as_dict:
-                    spec_fields[spec_field] = as_dict[key_name]
+                    spec_fields[spec_field] = as_dict[key]
                     break
             else:
                 continue
@@ -121,7 +121,8 @@ def _convert_dict_to_spec(as_dict: dict[str, Any]) -> Spec:
             spec_fields["license_type"] = License[spec_fields["license_type"].upper()]
         except KeyError:
             raise ValueError(
-                f"entry has invalid value for license_type: '{spec_fields['license_type']}'"
+                "entry has invalid value for license_type:"
+                " '{spec_fields['license_type']}'"
             )
 
     normalize("required", "is_required")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,9 +72,9 @@ class TestConfigParsing:
         # a little bit of alternative field name testing
         for spec in spec_list:
             spec_dict = spec._asdict()
-            spec_dict["filename"] = spec_dict.pop("path_spec")
+            spec_dict["Filename"] = spec_dict.pop("path_spec")
             if "license_type" in spec_dict:
-                spec_dict["usage"] = spec_dict.pop("license_type")
+                spec_dict["Usage Rights"] = spec_dict.pop("license_type")
             dict_list.append(spec_dict)
 
         with (tmp_path / "config.json").open("w") as config_file:


### PR DESCRIPTION
Was trying to create a resource pack, just for myself, as a CSV with the following columns:

```csv
Track Number,Filename,License,Hue
```

and I was getting an error:

```
ValueError: entry does not specify a path spec
```

Spec files aren't *really* fully-supported in v0.1, so this isn't something I felt like I *had* to do for the first release, but once I figured out the problem, I figured I might as well just put the fix in

The error was in two places:
- a typo
- failing to actually implement case-insensitive keys

Sorry, make that **three** places:
- the lack of an even-halway-decent normalization test

This PR fixes those issues.